### PR TITLE
商品詳細ページの商品データ反映とトップ画面のカテゴリー人気順表示

### DIFF
--- a/app/assets/stylesheets/products/_index.scss
+++ b/app/assets/stylesheets/products/_index.scss
@@ -32,7 +32,8 @@ body {
 
 .toppage-main {
   width: 100%;
-  height: 2614px;
+  height: 100%;
+  max-height: 2614px;
   background-color: rgb(245, 245, 245);
   &__category-top {
     margin-bottom: 16px;
@@ -58,7 +59,6 @@ body {
   &__category-bottom{
     display: block;
     width: 1020px;
-    height: 100%;
     background-color: rgb(245, 245, 245);
     padding: 42px 0 100px;
     flex-direction: column;

--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -209,6 +209,58 @@
     }
   }
 
+  &__change-status {
+    width: 700px;
+    &__box {
+      margin: 24px 0 24px 0;
+      background: #fff;
+      padding: 8px 16px 8px 16px;
+      p {
+        font-size: 16px;
+        text-align: center;
+      }
+      .change-status__box {
+        &--edit {
+          margin: 16px 0 16px 0;
+          background: #ea352d;
+          color: #fff;
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          transition: all ease-out .3s;
+          cursor: pointer;
+          text-align: center;
+        }
+        &--stop {
+          margin: 16px 0 16px 0;
+          background: #aaa;
+          color: #fff;
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          transition: all ease-out .3s;
+          cursor: pointer;
+          text-align: center;
+
+        }
+        &--delete {
+          margin: 16px 0 16px 0;
+          background: #aaa;
+          color: #fff;
+          display: block;
+          width: 100%;
+          line-height: 48px;
+          font-size: 14px;
+          transition: all ease-out .3s;
+          cursor: pointer;
+          text-align: center;
+        }
+      }
+    }
+  }
+
   &__message_contents {
     width: 700px;
     background-color: #fff;
@@ -302,9 +354,17 @@
   &__next_item{
     width: 100%;
     margin-top: 24px;
-    display: flex;
     justify-content: space-between;
+    position: relative;
     a {
+      color: #0099e8;
+    }
+    &--prev {
+      float: left;
+      color: #0099e8;
+    }
+    &--next {
+      float: right;
       color: #0099e8;
     }
   }

--- a/app/assets/stylesheets/products/_show.scss
+++ b/app/assets/stylesheets/products/_show.scss
@@ -215,48 +215,39 @@
       margin: 24px 0 24px 0;
       background: #fff;
       padding: 8px 16px 8px 16px;
+      color: #fff;
+      text-align: center;
+      width: 100%;
       p {
         font-size: 16px;
-        text-align: center;
+        color: #333;
       }
-      .change-status__box {
-        &--edit {
-          margin: 16px 0 16px 0;
-          background: #ea352d;
-          color: #fff;
-          display: block;
-          width: 100%;
-          line-height: 48px;
-          font-size: 14px;
-          transition: all ease-out .3s;
-          cursor: pointer;
-          text-align: center;
-        }
-        &--stop {
-          margin: 16px 0 16px 0;
-          background: #aaa;
-          color: #fff;
-          display: block;
-          width: 100%;
-          line-height: 48px;
-          font-size: 14px;
-          transition: all ease-out .3s;
-          cursor: pointer;
-          text-align: center;
-
-        }
-        &--delete {
-          margin: 16px 0 16px 0;
-          background: #aaa;
-          color: #fff;
-          display: block;
-          width: 100%;
-          line-height: 48px;
-          font-size: 14px;
-          transition: all ease-out .3s;
-          cursor: pointer;
-          text-align: center;
-        }
+      &--edit {
+        margin: 16px 0 16px 0;
+        background: #ea352d;
+        display: block;
+        line-height: 48px;
+        font-size: 14px;
+        transition: all ease-out .3s;
+        cursor: pointer;
+      }
+      &--stop {
+        margin: 16px 0 16px 0;
+        background: #aaa;
+        display: block;
+        line-height: 48px;
+        font-size: 14px;
+        transition: all ease-out .3s;
+        cursor: pointer;
+      }
+      &--delete {
+        margin: 16px 0 16px 0;
+        background: #aaa;
+        display: block;
+        line-height: 48px;
+        font-size: 14px;
+        transition: all ease-out .3s;
+        cursor: pointer;
       }
     }
   }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -1,12 +1,12 @@
 class ProductsController < ApplicationController
-  before_action :set_category, only: :index
+  before_action :set_category, :category_ranking, only: :index
 
   def index
     @products = Product.order('created_at DESC')
-    @products_ladies = Product.where(category_id: @ladies_ids).order('created_at DESC').limit(10)
-    @products_mens = Product.where(category_id: @mens_ids).order('created_at DESC').limit(10)
-    @products_electronics = Product.where(category_id: @electronics_ids).order('created_at DESC').limit(10)
-    @products_toys = Product.where(category_id: @toys_ids).order('created_at DESC').limit(10)
+    @products_ladies_index = @products_ladies.order('created_at DESC').limit(10)
+    @products_mens_index = @products_mens.order('created_at DESC').limit(10)
+    @products_electronics_index = @products_electronics.order('created_at DESC').limit(10)
+    @products_toys_index = @products_toys.order('created_at DESC').limit(10)
   end
 
   def show
@@ -14,6 +14,12 @@ class ProductsController < ApplicationController
     user = @product.user_id
     @user_products = Product.where(user_id: user)
     @category_products = Product.where(category_id: @product.category_id)
+    if params[:id].to_i - 1 != 0
+      @previous_product = Product.find((params[:id].to_i - 1).to_s)
+    end
+    if Product.find_by((params[:id].to_i + 1).to_s) != nil
+      @next_product = Product.find_by((params[:id].to_i + 1).to_s)
+    end
   end
 
   def completion
@@ -52,46 +58,90 @@ class ProductsController < ApplicationController
     ladies = Category.find_by name: "レディース"
     if ladies
       @ladies_ids = Category.descendants_of ladies
+      @products_ladies = Product.where(category_id: @ladies_ids)
     end
 
     mens = Category.find_by name: "メンズ"
     if mens
       @mens_ids = Category.descendants_of mens
+      @products_mens = Product.where(category_id: @mens_ids)
     end
 
     kids = Category.find_by name: "ベビー・キッズ"
     if kids
       @kids_ids = Category.descendants_of kids
+      @products_kids = Product.where(category_id: @kids_ids)
     end
 
     interia = Category.find_by name: "インテリア・住まい・小物"
     if interia
       @interia_ids = Category.descendants_of interia
+      @products_interia = Product.where(category_id: @interia_ids)
     end
 
     books = Category.find_by name: "本・音楽・ゲーム"
     if books
       @books_ids = Category.descendants_of books
+      @products_books = Product.where(category_id: @books_ids)
     end
 
     toys = Category.find_by name: "おもちゃ・ホビー・グッズ"
     if toys
       @toys_ids = Category.descendants_of toys
+      @products_toys = Product.where(category_id: @toys_ids)
     end
     
     beauties = Category.find_by name: "コスメ・香水・美容"
     if beauties
       @beauties_ids = Category.descendants_of beauties
+      @products_beauties = Product.where(category_id: @beauties_ids)
     end
    
     electronics = Category.find_by name: "家電・スマホ・カメラ"
     if electronics
       @electronics_ids = Category.descendants_of electronics
+      @products_electronics = Product.where(category_id: @electronics_ids)
     end
 
     sports = Category.find_by name: "スポーツ・レジャー"
     if sports
       @sports_ids = Category.descendants_of sports
+      @products_sports = Product.where(category_id: @sports_ids)
     end
+
+    handmade = Category.find_by name: "ハンドメイド"
+    if handmade
+      @handmade_ids = Category.descendants_of handmade
+      @products_handmade = Product.where(category_id: @handmade_ids)
+    end
+
+    tickets = Category.find_by name: "チケット"
+    if tickets
+      @tickets_ids = Category.descendants_of tickets
+      @products_tickets = Product.where(category_id: @tickets_ids)
+    end
+
+    bicycles = Category.find_by name: "自転車・オートバイ"
+    if bicycles
+      @bicycles_ids = Category.descendants_of bicycles
+      @products_bicycles = Product.where(category_id: @bicycles_ids)
+    end
+    
+    others = Category.find_by name: "その他"
+    if others
+      @others_ids = Category.descendants_of others
+      @products_others = Product.where(category_id: @others_ids)
+    end
+  end
+
+  def category_ranking
+    @ranking = [@products_ladies, @products_mens, @products_kids, @products_interia, @products_books, @products_toys, @products_beauties, @products_electronics, @products_sports, @products_handmade, @products_tickets, @products_bicycles, @products_others]
+    @ranking = @ranking.compact
+    @ranking.sort_by {|array| array.length}
+
+    @first_category = Category.find_by(id: @ranking[0][0].category_id) 
+    @second_category = Category.find_by(id: @ranking[1][0].category_id) unless @ranking[1][0].nil?
+    @third_category = Category.find_by(id: @ranking[2][0].category_id) unless @ranking[2][0].nil?
+    @fourth_category = Category.find_by(id: @ranking[3][0].category_id) unless @ranking[3][0].nil?
   end
 end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -139,7 +139,7 @@ class ProductsController < ApplicationController
     @ranking = @ranking.compact
     @ranking.sort_by {|array| array.length}
 
-    @first_category = Category.find_by(id: @ranking[0][0].category_id) 
+    @first_category = Category.find_by(id: @ranking[0][0].category_id) unless @ranking[0][0].nil?
     @second_category = Category.find_by(id: @ranking[1][0].category_id) unless @ranking[1][0].nil?
     @third_category = Category.find_by(id: @ranking[2][0].category_id) unless @ranking[2][0].nil?
     @fourth_category = Category.find_by(id: @ranking[3][0].category_id) unless @ranking[3][0].nil?

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -17,8 +17,8 @@ class ProductsController < ApplicationController
     if params[:id].to_i - 1 != 0
       @previous_product = Product.find((params[:id].to_i - 1).to_s)
     end
-    if Product.find_by((params[:id].to_i + 1).to_s) != nil
-      @next_product = Product.find_by((params[:id].to_i + 1).to_s)
+    if Product.find_by(id: (params[:id].to_i + 1).to_s) != nil
+      @next_product = Product.find_by(id: (params[:id].to_i + 1).to_s)
     end
   end
 

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -18,23 +18,24 @@
           おもちゃ・ホビー・グッズ
 
   .toppage-main__category-bottom
-    .toppage-main__category-name
-      .toppage-main__text
-        = @first_category.root.name + '新着アイテム'
-        .toppage-main__item-more
-          = link_to 'もっと見る >', '#'
-      .toppage-main__item
-        %ul.toppage-main__contents
-          = render partial: "products/product", collection: @ranking[0]
-
-    .toppage-main__category-name
-      .toppage-main__text
-        = @second_category.root.name + '新着アイテム'
-        .toppage-main__item-more
-          = link_to 'もっと見る >', '#'
-      .toppage-main__item
-        %ul.toppage-main__contents
-          = render partial: "products/product", collection: @ranking[1]
+    - if @ranking[0][0]
+      .toppage-main__category-name
+        .toppage-main__text
+          = @first_category.root.name + '新着アイテム'
+          .toppage-main__item-more
+            = link_to 'もっと見る >', '#'
+        .toppage-main__item
+          %ul.toppage-main__contents
+            = render partial: "products/product", collection: @ranking[0]
+    - if @ranking[1][0]
+      .toppage-main__category-name
+        .toppage-main__text
+          = @second_category.root.name + '新着アイテム'
+          .toppage-main__item-more
+            = link_to 'もっと見る >', '#'
+        .toppage-main__item
+          %ul.toppage-main__contents
+            = render partial: "products/product", collection: @ranking[1]
     - if @ranking[2][0]
       .toppage-main__category-name
         .toppage-main__text

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -17,53 +17,42 @@
         .toppage-main__logo
           おもちゃ・ホビー・グッズ
 
-  -# .toppage-main__category-bottom
-  -#   .toppage-main__category-name
-  -#     .toppage-main__text
-  -#       - @categories_main.each do |category|
-  -#         = category.name + '新着アイテム'
-  -#         .toppage-main__item-more
-  -#           = link_to 'もっと見る >', '#'
-  -#         .toppage-main__item
-  -#           %ul.toppage-main__contents
-  -#             = render partial: "products/product", collection: @products
-
   .toppage-main__category-bottom
     .toppage-main__category-name
       .toppage-main__text
-        レディース新着アイテム
+        = @first_category.root.name + '新着アイテム'
         .toppage-main__item-more
           = link_to 'もっと見る >', '#'
       .toppage-main__item
         %ul.toppage-main__contents
-          = render partial: "products/product", collection: @products_ladies
+          = render partial: "products/product", collection: @ranking[0]
 
     .toppage-main__category-name
       .toppage-main__text
-        メンズ新着アイテム
+        = @second_category.root.name + '新着アイテム'
         .toppage-main__item-more
           = link_to 'もっと見る >', '#'
       .toppage-main__item
         %ul.toppage-main__contents
-          = render partial: "products/product", collection: @products_mens
-
-    .toppage-main__category-name
-      .toppage-main__text
-        家電・スマホ・カメラ新着アイテム
-        .toppage-main__item-more
-          = link_to 'もっと見る >', '#'
-      .toppage-main__item
-        %ul.toppage-main__contents
-          = render partial: "products/product", collection: @products_electronics
-
-    .toppage-main__category-name
-      .toppage-main__text
-        おもちゃ・ホビー・グッズ新着アイテム
-        .toppage-main__item-more
-          = link_to 'もっと見る >', '#'
-      .toppage-main__item
-        .toppage-main__contents
-          = render partial: "products/product", collection: @products_toys
+          = render partial: "products/product", collection: @ranking[1]
+    - if @ranking[2][0]
+      .toppage-main__category-name
+        .toppage-main__text
+          = @third_category.root.name + '新着アイテム'
+          .toppage-main__item-more
+            = link_to 'もっと見る >', '#'
+        .toppage-main__item
+          %ul.toppage-main__contents
+            = render partial: "products/product", collection: @ranking[2]
+    - if @ranking[3][0]
+      .toppage-main__category-name
+        .toppage-main__text
+          = @fourth_category.root.name + '新着アイテム'
+          .toppage-main__item-more
+            = link_to 'もっと見る >', '#'
+        .toppage-main__item
+          .toppage-main__contents
+            = render partial: "products/product", collection: @ranking[3]
 
 = render 'shared/sellbutton'
 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -126,10 +126,10 @@
   - if @product.user_id == current_user.id
     .item_detail_container__change-status
       .item_detail_container__change-status__box
-        = link_to "商品の編集", "", class: 'change-status__box--edit'
+        = link_to "商品の編集", "", class: 'item_detail_container__change-status__box--edit'
         %p or
-        = link_to "出品を一旦停止する", "", class: 'change-status__box--stop'
-        = link_to "この商品を削除する", "", class: 'change-status__box--delete'
+        = link_to "出品を一旦停止する", "", class: 'item_detail_container__change-status__box--stop'
+        = link_to "この商品を削除する", "", class: 'item_detail_container__change-status__box--delete'
 
   .item_detail_container__message_contents
     .item_detail_container__message_contents--message_list
@@ -171,12 +171,12 @@
     %ul.item_detail_container__next_item
       - if @previous_product
         %li.item_detail_container__next_item--prev
-          = link_to "/products/#{@previous_product.id}" do
+          = link_to product_path(@previous_product) do
             = icon 'fas', 'chevron-left'
             = @previous_product.name
       - if @next_product
         %li.item_detail_container__next_item--next
-          = link_to "/products/#{@next_product.id}" do
+          = link_to product_path(@next_product) do
             = @next_product.name
             = icon 'fas', 'chevron-right'
     .item_detail_container__sns_box

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -123,6 +123,14 @@
           = icon 'fas', 'lock'
           あんしん・あんぜんへの取り組み
 
+  - if @product.user_id == current_user.id
+    .item_detail_container__change-status
+      .item_detail_container__change-status__box
+        = link_to "商品の編集", "", class: 'change-status__box--edit'
+        %p or
+        = link_to "出品を一旦停止する", "", class: 'change-status__box--stop'
+        = link_to "この商品を削除する", "", class: 'change-status__box--delete'
+
   .item_detail_container__message_contents
     .item_detail_container__message_contents--message_list
       %ul
@@ -161,14 +169,16 @@
         コメントする
 
     %ul.item_detail_container__next_item
-      %li.item_detail_container__next_item--prev
-        = link_to '' do
-          = icon 'fas', 'chevron-left'
-          ライオンさん
-      %li.item_detail_container__next_item--next
-        = link_to '' do
-          ネコちゃん
-          = icon 'fas', 'chevron-right'
+      - if @previous_product
+        %li.item_detail_container__next_item--prev
+          = link_to "/products/#{@previous_product.id}" do
+            = icon 'fas', 'chevron-left'
+            = @previous_product.name
+      - if @next_product
+        %li.item_detail_container__next_item--next
+          = link_to "/products/#{@next_product.id}" do
+            = @next_product.name
+            = icon 'fas', 'chevron-right'
     .item_detail_container__sns_box
       %ul.item_detail_container__sns_box__sns_icons
         %li
@@ -206,7 +216,8 @@
         %span メルカリ
       = icon 'fas', 'chevron-right', class: 'nav__lists__list--icon'
     %li.nav_item__lists__list.nav_item__lists__list--item
-      %span トラさん
+      %span
+        = @product.name
     
 = render 'shared/appbanner'
   


### PR DESCRIPTION
# What
商品詳細ページに商品の情報を反映させる。
下部分のユーザーの他の出品商品や他の同カテゴリーの商品を表示する。
また、トップページのカテゴリーを投稿数の多い順に並ぶように編集。
何も商品がない場合はカテゴリーが表示されないように編集。

#Why
商品の編集ボタンや削除ボタンを設けることで、これから取り掛かる削除や編集の機能への橋渡しとするため。
また、カテゴリーの出品数順に表示させることで、商品のないカテゴリーを表示しないようにするため。